### PR TITLE
When using a Resource Owner Password grant type, Oauth2 should respon…

### DIFF
--- a/src/Exception/OAuthServerException.php
+++ b/src/Exception/OAuthServerException.php
@@ -120,7 +120,7 @@ class OAuthServerException extends \Exception
      */
     public static function invalidCredentials()
     {
-        return new static('The user credentials were incorrect.', 6, 'invalid_credentials', 401);
+        return new static('The user credentials were incorrect.', 6, 'invalid_grant', 400);
     }
 
     /**


### PR DESCRIPTION
…d with an HTTP 400 (Bad Request), not a 401.

See this stackoverflow question for a better explanation: https://stackoverflow.com/questions/22586825/oauth-2-0-why-does-the-authorization-server-return-400-instead-of-401-when-the